### PR TITLE
swi calcd. independent of uncert. data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,14 +5,15 @@ Changelog
 Unreleased Changes in master
 ============================
 
--
-
+- SWI calculation in swi_error_prop() decoupled form input uncertainty data availability
+- quality flags normalized within swi_error_prop() and returned as percentages
+- restarting calculation with stored parameters (gain_in/out)
+- tests for above changes and swi_error_prop()/calc_swi_ts() result equivalence
 
 Version 1.0.0 (2023-01-13)
 ==========================
 
-- Includes improved error estimation scheme from `Pasik et al. (2023, submitted)`
-  and `De Santis and Biondi (2018) <https://doi.org/10.29007/kvhb>`_.
+- Includes an uncertainty characterization scheme from `Pasik et al. (2023, in review) <https://doi.org/10.5194/egusphere-2023-47>`_.
 - Public release on pypi (``pip install pyswi``)
 - Inclusion of iterative storage module
 

--- a/src/pyswi/swi_ts/swi_ts.py
+++ b/src/pyswi/swi_ts/swi_ts.py
@@ -61,13 +61,12 @@ def swi_error_prop(ssm, t_value, t_noise, swi_error, gain_in=None, nan=-9999.):
     qflag = np.ones((len_ssm, len_T))
 
     if gain_in is None:
-        swi[0] = ssm['sm'][0]
-        swi_noise[0] = ssm['sm_uncertainty'][0]
-        qflag[0] = 1.
-        last_jd = ssm['sm_jd'][0]
+        first_ssm_idx = np.argmax((ssm['sm'] != nan) & ~np.isnan(ssm['sm']))
+        first_noise_idx = np.argmax((ssm['sm_uncertainty'] != nan) & ~np.isnan(ssm['sm_uncertainty']))
+        swi[first_ssm_idx] = ssm['sm'][first_ssm_idx]
+        last_jd = ssm['sm_jd'][first_ssm_idx]
         gain_curr = [1] * len_T
-        contr1_curr = [ssm['sm_uncertainty'][np.argmax((ssm['sm_uncertainty'] != nan) &
-                                                       ~np.isnan(ssm['sm_uncertainty']))]**2] * len_T
+        contr1_curr = [ssm['sm_uncertainty'][first_noise_idx]**2] * len_T
         G_curr = [0] * len_T
         JT_curr = [0] * len_T # Jacobian term
     else:

--- a/src/pyswi/swi_ts/swi_ts.py
+++ b/src/pyswi/swi_ts/swi_ts.py
@@ -117,9 +117,9 @@ def swi_error_prop(ssm, t_value, t_noise, swi_error, gain_in=None, nan=-9999.):
             j += 1
 
         for c in range(len_T):
-            if ssm['sm'][j] != nan and ~np.isnan(ssm['sm'][j]):
+            if ssm['sm'][i] != nan and ~np.isnan(ssm['sm'][i]):
                 qflag[i, c] = 1 + qflag[i-1][c] * np.exp(-(1. / float(t_value[c])))
-                if ssm['sm_uncertainty'][i] != nan and ~np.isnan(ssm['sm_uncertainty'][j]):
+                if ssm['sm_uncertainty'][i] != nan and ~np.isnan(ssm['sm_uncertainty'][i]):
                     swi_noise[i, c] = sqrt(contr1_curr[c] + contr2[c] + swi_error[c])
                 else:
                     swi_noise[i, c] = np.nan

--- a/src/pyswi/swi_ts/swi_ts.py
+++ b/src/pyswi/swi_ts/swi_ts.py
@@ -56,8 +56,8 @@ def swi_error_prop(ssm, t_value, t_noise, swi_error, gain_in=None, nan=-9999.):
 
     len_ssm = len(ssm)
     len_T = len(t_value)
-    swi = np.zeros((len_ssm, len_T))
-    swi_noise = np.zeros((len_ssm, len_T))
+    swi = np.full((len_ssm, len_T), np.nan)
+    swi_noise = np.full((len_ssm, len_T), np.nan)
     qflag = np.ones((len_ssm, len_T))
 
     if gain_in is None:
@@ -91,9 +91,9 @@ def swi_error_prop(ssm, t_value, t_noise, swi_error, gain_in=None, nan=-9999.):
     G_old = [None] * len_T
     JT_old = [None] * len_T
 
-    j = 0
+    j = 1
 
-    for i in range(len_ssm):
+    for i in range(1, len_ssm):
         while j < len_ssm and ssm['sm_jd'][j] <= ssm['sm_jd'][i]:
             if ssm['sm'][j] != nan and ~np.isnan(ssm['sm'][j]):
                 time_diff = ssm['sm_jd'][j] - last_jd

--- a/src/pyswi/swi_ts/swi_ts.py
+++ b/src/pyswi/swi_ts/swi_ts.py
@@ -91,9 +91,9 @@ def swi_error_prop(ssm, t_value, t_noise, swi_error, gain_in=None, nan=-9999.):
     G_old = [None] * len_T
     JT_old = [None] * len_T
 
-    j = 1
+    j = 1 + first_ssm_idx
 
-    for i in range(1, len_ssm):
+    for i in range(j, len_ssm):
         while j < len_ssm and ssm['sm_jd'][j] <= ssm['sm_jd'][i]:
             if ssm['sm'][j] != nan and ~np.isnan(ssm['sm'][j]):
                 time_diff = ssm['sm_jd'][j] - last_jd

--- a/src/pyswi/swi_ts/swi_ts.py
+++ b/src/pyswi/swi_ts/swi_ts.py
@@ -59,6 +59,8 @@ def swi_error_prop(ssm, t_value, t_noise, swi_error, gain_in=None, nan=-9999.):
     swi = np.full((len_ssm, len_T), np.nan)
     swi_noise = np.full((len_ssm, len_T), np.nan)
     qflag = np.ones((len_ssm, len_T))
+    qflag_norm = [np.sum(np.exp(-(np.tensordot(np.arange(1000, dtype=np.float32),
+                                              (1. / t), axes=0))), axis=0) for t in t_value]
 
     if gain_in is None:
         first_ssm_idx = np.argmax((ssm['sm'] != nan) & ~np.isnan(ssm['sm']))
@@ -142,7 +144,7 @@ def swi_error_prop(ssm, t_value, t_noise, swi_error, gain_in=None, nan=-9999.):
     for i, t in enumerate(t_value):
         swi_ts['swi_{}'.format(t)] = swi[:, i]
         swi_ts['swi_noise_{}'.format(t)] = swi_noise[:, i]
-        swi_ts['qflag_{}'.format(t)] = qflag[:, i]
+        swi_ts['qflag_{}'.format(t)] = 100 * qflag[:, i] / qflag_norm[i]
 
     return swi_ts, gain_out
 

--- a/tests/test_swi_ts.py
+++ b/tests/test_swi_ts.py
@@ -130,7 +130,7 @@ def test_process_swi_gain():
 def test_process_swi_not_daily_out():
     """
     Test correct calculation of SWI with irregular timestamps,
-    compared to the a hardcoded calculation output.
+    compared to a hardcoded calculation output.
     """
     t_value = [5, 50, 100]
 
@@ -260,7 +260,7 @@ def test_equivalency():
         np.testing.assert_array_almost_equal(swi_1['swi_{}'.format(t)],
                                              swi_2['swi_{}'.format(t)], 4)
 
-def test_swi_error_prop_independent():
+def test_swi_error_prop_independence():
     """
     Test the ability of swi_error_prop() to correctly calculate SWI
     independently of input uncertainty data availability.
@@ -290,6 +290,42 @@ def test_swi_error_prop_independent():
                             np.nan, 42.430466, 38.023155]),
         'swi_100': ([10., 15.025, 20.066666, 25.124996, 30.199991, 35.29165,
                      np.nan, 41.928066, 37.76523])
+    }
+
+    for t in t_value:
+        np.testing.assert_array_almost_equal(swi['swi_{}'.format(t)],
+                                             swi_ref['swi_{}'.format(t)], 4)
+
+def test_swi_error_prop_nan_handling():
+    """
+    Test the ability of swi_error_prop() to handle nan values at the start,
+    in the middle, and at the end of the input ssm array.
+    Compare against a hardcoded result.
+    """
+    t_value = [5, 50, 100]
+    t_noise = np.array([.5, 5, 10])
+    swi_error = np.array([.0001, .0002, .0003])
+
+    swi_jd = pd.date_range(
+        '2007-01-01', periods=14).to_julian_date().values.astype(np.float64)
+
+    sm = np.array([999, 999, 999, 10, 20, 30, 40, 50, 60, 999, 80, 10, 999, 999])
+    sm_uncertainty = np.array([999, 999, 999, 1, 2, 3, 4, 5, 6, 999, 8, 1, 999, 999])
+
+    dtype = np.dtype([('sm_jd', np.float64), ('sm', np.float32), ('sm_uncertainty', np.float32)])
+    ssm_ts = unstructured_to_structured(
+        np.hstack((swi_jd[:, np.newaxis], sm[:, np.newaxis], sm_uncertainty[:, np.newaxis])), dtype=dtype)
+
+    swi, gain = swi_error_prop(ssm_ts, t_value=t_value, t_noise=t_noise,
+                               swi_error=swi_error, nan=999)
+
+    swi_ref = {
+        'swi_5': np.array([np.nan, np.nan, np.nan, 10., 15.49834, 21.32452, 27.472094, 33.93228, 40.69421,
+                           np.nan, 51.660824, 41.072067, np.nan, np.nan]),
+        'swi_50': np.array([np.nan, np.nan, np.nan, 10., 15.049998, 20.133324, 25.249971, 30.399931, 35.58319,
+                            np.nan, 42.430466, 38.023155, np.nan, np.nan]),
+        'swi_100': ([np.nan, np.nan, np.nan, 10., 15.025, 20.066666, 25.124996, 30.199991, 35.29165,
+                     np.nan, 41.928066, 37.76523, np.nan, np.nan])
     }
 
     for t in t_value:

--- a/tests/test_swi_ts.py
+++ b/tests/test_swi_ts.py
@@ -331,3 +331,46 @@ def test_swi_error_prop_nan_handling():
     for t in t_value:
         np.testing.assert_array_almost_equal(swi['swi_{}'.format(t)],
                                              swi_ref['swi_{}'.format(t)], 4)
+
+def test_swi_error_prop_restarting():
+    """
+    Test restarting swi_error_prop() calculation with stored
+    intermediate parmeters (gain_out). Compare against a hardcoded result.
+    """
+
+    t_value = [5, 50, 100]
+    t_noise = np.array([.5, 5, 10])
+    swi_error = np.array([.0001, .0002, .0003])
+
+    swi_jd = pd.date_range(
+        '2007-01-01', periods=9).to_julian_date().values.astype(np.float64)
+
+    sm = np.array([10, 20, 30, 40, 50, 60, 999, 80, 10])
+
+    sm_uncertainty = np.array([1, 2, 3, 4, 5, 6, 999, 8, 1])
+
+    dtype = np.dtype([('sm_jd', np.float64), ('sm', np.float32), ('sm_uncertainty', np.float32)])
+    ssm_ts_1 = unstructured_to_structured(
+        np.hstack((swi_jd[:5, np.newaxis], sm[:5, np.newaxis], sm_uncertainty[:5, np.newaxis])), dtype=dtype)
+
+    ssm_ts_2 = unstructured_to_structured(
+        np.hstack((swi_jd[5:, np.newaxis], sm[5:, np.newaxis], sm_uncertainty[5:, np.newaxis])), dtype=dtype)
+
+    swi_1, gain_1 = swi_error_prop(ssm_ts_1, t_value=t_value, t_noise=t_noise,
+                                   swi_error=swi_error, nan=999)
+    swi_2, gain_2 = swi_error_prop(ssm_ts_2, t_value=t_value, t_noise=t_noise,
+                                   swi_error=swi_error, gain_in=gain_1, nan=999)
+
+    swi_ref = {
+        'swi_5': np.array([10., 15.49834, 21.32452, 27.472094, 33.93228, 40.69421,
+                           np.nan, 51.660824, 41.072067]),
+        'swi_50': np.array([10., 15.049998, 20.133324, 25.249971, 30.399931, 35.58319,
+                            np.nan, 42.430466, 38.023155]),
+        'swi_100': ([10., 15.025, 20.066666, 25.124996, 30.199991, 35.29165,
+                     np.nan, 41.928066, 37.76523])
+    }
+
+    for t in t_value:
+        swi_sum = swi_1['swi_{}'.format(t)].tolist() + \
+                  swi_2['swi_{}'.format(t)].tolist()
+        np.testing.assert_array_almost_equal(swi_sum, swi_ref['swi_{}'.format(t)], 4)

--- a/tests/test_swi_ts.py
+++ b/tests/test_swi_ts.py
@@ -263,8 +263,8 @@ def test_equivalency():
 def test_swi_error_prop_independent():
     """
     Test the ability of swi_error_prop() to correctly calculate SWI
-    independently of input noise data availability. Compare against
-    a hardcoded output as well as that of calc_swi_ts().
+    independently of input uncertainty data availability.
+    Compare against a hardcoded result.
     """
     t_value = [5, 50, 100]
     t_noise = np.array([.5, 5, 10])
@@ -274,14 +274,14 @@ def test_swi_error_prop_independent():
         '2007-01-01', periods=9).to_julian_date().values.astype(np.float64)
 
     sm = np.array([10, 20, 30, 40, 50, 60, 999, 80, 10])
-    sm_uncertainty = np.array([1, 2, 3, 4, 5, 6, 999, 8, 1])
+    sm_uncertainty = np.array([999, 999, 3, 4, 5, 6, 999, 8, 1])
 
     dtype = np.dtype([('sm_jd', np.float64), ('sm', np.float32), ('sm_uncertainty', np.float32)])
     ssm_ts = unstructured_to_structured(
         np.hstack((swi_jd[:, np.newaxis], sm[:, np.newaxis], sm_uncertainty[:, np.newaxis])), dtype=dtype)
 
-    swi_1, gain_1 = swi_error_prop(ssm_ts, t_value=t_value, t_noise=t_noise,
-                                   swi_error=swi_error, nan=999)
+    swi, gain = swi_error_prop(ssm_ts, t_value=t_value, t_noise=t_noise,
+                               swi_error=swi_error, nan=999)
 
     swi_ref = {
         'swi_5': np.array([10., 15.49834, 21.32452, 27.472094, 33.93228, 40.69421,
@@ -293,5 +293,5 @@ def test_swi_error_prop_independent():
     }
 
     for t in t_value:
-        np.testing.assert_array_almost_equal(swi_1['swi_{}'.format(t)],
+        np.testing.assert_array_almost_equal(swi['swi_{}'.format(t)],
                                              swi_ref['swi_{}'.format(t)], 4)


### PR DESCRIPTION
1) swi calculation now decoupled from ssm_uncert. availability
2) uncert. calculation initiated at first valid ssm_uncert. data point, even if ssm available beofre (see above)
3) contr1 param. intiated from first valid ssm_uncert. value, not as before from the _FillValue (-9999.)
4) quality flags are normalized within the function and returned as percentage (as required for masking)
5) fixed restarting swi with gain__in parameters
6) added tests for the above changes